### PR TITLE
DATASTD-819 renamed Credential.StateOfIssueStateAbbreviationType

### DIFF
--- a/v2.1/Schemas/Ed-Fi-Core.xsd
+++ b/v2.1/Schemas/Ed-Fi-Core.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by Melodie Comer (Double Line, Inc.) -->
 <!-- (c)2015 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/0200" xmlns:ann="http://ed-fi.org/annotation" targetNamespace="http://ed-fi.org/0200" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:import namespace="http://ed-fi.org/annotation" schemaLocation="SchemaAnnotation.xsd"/>
@@ -12959,7 +12960,7 @@ Student late arrival/early dismissal.</xs:documentation>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="StateOfIssueStateAbbreviationType" type="StateAbbreviationType" minOccurs="0">
+			<xs:element name="StateOfIssueStateAbbreviation" type="StateAbbreviationType" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The abbreviation for the name of the state (within the United States) or extra-state jurisdiction in which a license/credential was issued.</xs:documentation>
 					<xs:appinfo>


### PR DESCRIPTION
DATASTD-819 renamed Credential.StateOfIssueStateAbbreviationType to Credential.StateOfIssueStateAbbreviation to follow the enumeration element naming pattern.
