### PR TITLE
DATASTD-866 Standardized all integer types to use xs:int.

### DIFF
--- a/v2.1/Schemas/Ed-Fi-Core.xsd
+++ b/v2.1/Schemas/Ed-Fi-Core.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by Melodie Comer (Double Line, Inc.) -->
+<!-- edited with XMLSpy v2016 rel. 2 (x64) (http://www.altova.com) by Lillie Anderson (Double Line, Inc.) -->
 <!-- (c)2015 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/0200" xmlns:ann="http://ed-fi.org/annotation" targetNamespace="http://ed-fi.org/0200" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:import namespace="http://ed-fi.org/annotation" schemaLocation="SchemaAnnotation.xsd"/>
@@ -1450,7 +1450,7 @@ Withdrawn.</xs:documentation>
 							</xs:appinfo>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="DisciplineActionLength" type="xs:integer" minOccurs="0">
+					<xs:element name="DisciplineActionLength" type="xs:int" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The length of time in school days for the DisciplineAction (e.g. removal, detention), if applicable.</xs:documentation>
 							<xs:appinfo>
@@ -1458,7 +1458,7 @@ Withdrawn.</xs:documentation>
 							</xs:appinfo>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="ActualDisciplineActionLength" type="xs:integer" minOccurs="0">
+					<xs:element name="ActualDisciplineActionLength" type="xs:int" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>Indicates the actual length in school days of a student's disciplinary assignment.</xs:documentation>
 							<xs:appinfo>
@@ -14745,7 +14745,7 @@ Met standard
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="OrderOfPriority" type="xs:positiveInteger" minOccurs="0">
+			<xs:element name="OrderOfPriority" type="xs:int" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The order of priority assigned to telephone numbers to define which number to attempt first, second, etc.</xs:documentation>
 					<xs:appinfo>


### PR DESCRIPTION
This corrects uses of xs:integer and xs:postiveinteger
